### PR TITLE
The 'ascii' package is on CRAN again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
   markdown,
   knitr,
   R.devices,
-  base64enc
+  base64enc,
+  ascii
 SuggestsNote:
   Recommended: R.devices, base64enc, markdown
 VignetteBuilder: R.rsp

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ Package: R.rsp
 
 Version: 0.44.0-9000 [2020-07-09]
 
- * ...
+ * Package 'ascii' has returned to CRAN and is no longer deprecated.
 
 
 Version: 0.44.0 [2020-07-09]

--- a/R/compileAsciiDoc.R
+++ b/R/compileAsciiDoc.R
@@ -5,9 +5,6 @@
 #
 # \description{
 #  @get "title".
-#
-#  \emph{NOTE: This function requires the \bold{ascii} package, which was
-#  "removed" (archived) from CRAN on 2019-01-26.}
 # }
 #
 # @synopsis

--- a/R/compileAsciiDocNoweb.R
+++ b/R/compileAsciiDocNoweb.R
@@ -5,9 +5,6 @@
 #
 # \description{
 #  @get "title".
-#
-#  \emph{NOTE: This function requires the \bold{ascii} package, which was
-#  "removed" (archived) from CRAN on 2019-01-26.}
 # }
 #
 # @synopsis

--- a/man/compileAsciiDoc.Rd
+++ b/man/compileAsciiDoc.Rd
@@ -14,9 +14,6 @@
 
 \description{
  Compiles an AsciiDoc file.
-
- \emph{NOTE: This function requires the \bold{ascii} package, which was
- "removed" (archived) from CRAN on 2019-01-26.}
 }
 
 \usage{

--- a/man/compileAsciiDocNoweb.Rd
+++ b/man/compileAsciiDocNoweb.Rd
@@ -14,9 +14,6 @@
 
 \description{
  Compiles an AsciiDoc noweb file.
-
- \emph{NOTE: This function requires the \bold{ascii} package, which was
- "removed" (archived) from CRAN on 2019-01-26.}
 }
 
 \usage{


### PR DESCRIPTION
These are some minor changes now that the 'ascii' package is back on CRAN. I hope that this is useful.

Sincerely, Mark.