### PR TITLE
Suppress PTEX info in vignette for reproducibility

### DIFF
--- a/vignettes/Dynamic_document_creation_using_RSP.tex.rsp
+++ b/vignettes/Dynamic_document_creation_using_RSP.tex.rsp
@@ -150,6 +150,8 @@ devOptions("png", width=840)
 \author{<%@meta name="author"%>}
 \date{<%=format(as.Date(R.rsp$date), format="%B %d, %Y")%>}
 
+\pdfsuppressptexinfo=-1
+
 \begin{document}
 
 \maketitle


### PR DESCRIPTION
Otherwise, we get PTEX.FileName metadata for an included figure containing the build path:

```
$ strings Dynamic_document_creation_using_RSP.pdf | grep build
/PTEX.FileName (/build/r-cran-r.rsp-0.44.0+ds/vignettes/figures//MyFigure,yeah,cool.pdf)
```