### PR TITLE
Use UTF-8 acute accent in regular expression

### DIFF
--- a/inst/rsp/R/system/packageDetails.html.rsp
+++ b/inst/rsp/R/system/packageDetails.html.rsp
@@ -47,7 +47,7 @@ Package:
 
   # Linkify all http:// words.
   details <- lapply(details, FUN=function(x) {
-    x <- gsub("((http|ftp)://[^ \t\n\r\v,;'`´\"><()]*)", "<a href=\"\\1\">\\1</a>", x);
+    x <- gsub("((http|ftp)://[^ \t\n\r\v,;'`Â´\"><()]*)", "<a href=\"\\1\">\\1</a>", x);
     x <- gsub("[.]\">ftp://", "\">ftp://", x);
     x <- gsub("[.]</a>", "</a>.", x);
     x;


### PR DESCRIPTION
Formerly, it was ISO-8859-1.  This fixes a [national-encoding](https://lintian.debian.org/tags/national-encoding) warning in the Debian package.