### PR TITLE
Remove unused (and unclosed) <div> tag in intro vignette.

### DIFF
--- a/vignettes/RSP_intro.html.rsp
+++ b/vignettes/RSP_intro.html.rsp
@@ -45,7 +45,6 @@ devOptions("png", width = 840)
 	      
 ---
 # <%= title %>
-<div class="footer">
 <% } # slide() %>
 
 <!DOCTYPE html>


### PR DESCRIPTION
The CSS for div.footer and the closing </div> tag were removed in 53cefa3.  Furthermore, with the tag, the markdown is not rendered correctly when using remark 0.15.0:

![image](https://user-images.githubusercontent.com/1992248/157161028-061ca470-70a6-4796-822c-f82b8ad161c9.png)
